### PR TITLE
Make volar understand the global components

### DIFF
--- a/packages/ui/volar.d.ts
+++ b/packages/ui/volar.d.ts
@@ -15,7 +15,6 @@ declare module '@vue/runtime-core' {
     XForm: typeof import('@indielayer/ui')['XForm']
     XIcon: typeof import('@indielayer/ui')['XIcon']
     XImage: typeof import('@indielayer/ui')['XImage']
-    //XAbac: typeof import('@indielayer/ui')['XAbac']
     XInput: typeof import('@indielayer/ui')['XInput']
     XLink: typeof import('@indielayer/ui')['XLink']
     XMenu: typeof import('@indielayer/ui')['XMenu']

--- a/packages/ui/volar.d.ts
+++ b/packages/ui/volar.d.ts
@@ -1,4 +1,4 @@
-declare module 'vue' {
+declare module '@vue/runtime-core' {
   export interface GlobalComponents {
     XAlert: typeof import('@indielayer/ui')['XAlert']
     XAvatar: typeof import('@indielayer/ui')['XAvatar']
@@ -15,7 +15,7 @@ declare module 'vue' {
     XForm: typeof import('@indielayer/ui')['XForm']
     XIcon: typeof import('@indielayer/ui')['XIcon']
     XImage: typeof import('@indielayer/ui')['XImage']
-    XAbac: typeof import('@indielayer/ui')['XAbac']
+    //XAbac: typeof import('@indielayer/ui')['XAbac']
     XInput: typeof import('@indielayer/ui')['XInput']
     XLink: typeof import('@indielayer/ui')['XLink']
     XMenu: typeof import('@indielayer/ui')['XMenu']


### PR DESCRIPTION
Following volar documentation the declared module shouldn't be "vue" but rather "@vue/runtime-core". https://marketplace.visualstudio.com/items?itemName=Vue.volar
and
https://github.com/vuejs/core/pull/3399

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

**Other information:**
