### PR TITLE
feat(upload): add resetUpload method to clear uploaded files

### DIFF
--- a/.changeset/yellow-owls-smell.md
+++ b/.changeset/yellow-owls-smell.md
@@ -1,0 +1,5 @@
+---
+"@indielayer/ui": minor
+---
+
+feat(upload): add resetUpload method to clear uploaded files and reset validation state

--- a/packages/ui/src/components/upload/Upload.vue
+++ b/packages/ui/src/components/upload/Upload.vue
@@ -267,6 +267,16 @@ async function upload() {
   validate(modelValue.value)
 }
 
+function resetUpload() {
+  modelValue.value = []
+  errorInternal.value = ''
+  isFirstValidation.value = false
+
+  if (elRef.value && 'value' in elRef.value) {
+    (elRef.value as HTMLInputElement).value = ''
+  }
+}
+
 const {
   errorInternal,
   hideFooterInternal,
@@ -280,7 +290,7 @@ const {
 
 const { styles, classes, className } = useTheme('Upload', {}, props)
 
-defineExpose({ focus, blur, reset, validate, setError })
+defineExpose({ focus, blur, reset, validate, setError, resetUpload })
 </script>
 
 <template>


### PR DESCRIPTION
### 🔗 Linked issue

N/A

<!-- Please ensure there is an open issue and mention its number as #123 -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

**Do we need to publish a new version of a package?**
- [x] Add a changeset `pnpm changeset` and select what [semver](https://semver.org/) changes your PR is adding
  - commit and push the generated *changeset* file

### 📝 Checklist
<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR adds a new method resetUpload() to the <x-upload> component.

It allows:
- Manually clearing selected file(s)
- Resetting validation state (e.g., after successful form submission)
- Resetting native input value to allow re-upload of the same file
  
Currently, there is no built-in way to programmatically reset the upload input. This makes it difficult to clear the component after successful form submissions or cancellation actions. This method provides a clean, predictable way to reset the UI and internal state.

Tested successfully in a Nuxt 3 app using both direct <x-upload /> usage and custom wrapper components.
