### PR TITLE
chore(cloud): add Cursor Cloud Agent environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "Indielayer UI",
+  "install": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm install 24 && nvm alias default 24 && export PATH=\"$NVM_BIN:$PATH\" && corepack enable && corepack prepare pnpm@11.1.3 --activate && pnpm install --frozen-lockfile && pnpm --dir packages/ui generate",
+  "terminals": [
+    {
+      "name": "ui-dev",
+      "command": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 24 && export PATH=\"$NVM_BIN:$PATH\" && pnpm --dir packages/ui exec vite dev --mode docs --host 0.0.0.0 --port 5173"
+    }
+  ],
+  "ports": [5173]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,20 @@ Vue 3 component library (`@indielayer/ui`) in a pnpm monorepo. Primary package: 
 - Node.js 24+
 - pnpm 11+ (use `pnpm`, not npm/yarn)
 
+## Cursor Cloud specific instructions
+
+The Cloud Agent environment (`.cursor/environment.json`) is provisioned by the base
+image's `nvm` with Node 24 installed. `.cursor/environment.json` activates Node 24 for
+the `install` step and the `ui-dev` terminal (the docs dev server on port `5173`).
+
+Ad-hoc shells default to the exec-daemon's Node 22, which shadows `nvm` in `PATH`. Before
+running any `pnpm` command manually (lint, typecheck, tests, build), activate Node 24 and
+put it ahead of the exec-daemon in `PATH`:
+
+```bash
+export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && nvm use 24 && export PATH="$NVM_BIN:$PATH"
+```
+
 ## Commands
 
 From the repo root:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cursor Cloud Agent development environment for the `@indielayer/ui` monorepo so future Cloud Agents boot into a fully working, Node 24 setup.

The repository requires **Node.js 24+** (`AGENTS.md`, `CONTRIBUTING.md`, CI uses Node 24), but the Cloud Agent base image's exec-daemon shadows `nvm` in `PATH` and defaults shells to Node 22. The environment config and an `AGENTS.md` note handle activating Node 24 reliably.

## Changes

- **`.cursor/environment.json`** (new):
  - `install`: activates Node 24 via `nvm` (installs if missing, sets default), prepends `$NVM_BIN` ahead of the exec-daemon in `PATH`, enables `corepack`/pnpm `11.1.3`, runs `pnpm install --frozen-lockfile`, then `pnpm --dir packages/ui generate`.
  - `terminals.ui-dev`: runs the docs dev server (`vite dev --mode docs`) on port `5173`.
  - `ports`: exposes `5173`.
- **`AGENTS.md`**: adds a `## Cursor Cloud specific instructions` section documenting the Node 24 `PATH` activation one-liner for ad-hoc shells.

## Validation (on Node 24 in the Cloud Agent VM)

| Check | Result |
|-------|--------|
| `pnpm install --frozen-lockfile` | Passed (idempotent — "Already up to date" on 2nd run) |
| `pnpm --dir packages/ui generate` | Passed |
| `pnpm run lint:ui` | Passed |
| `pnpm run typecheck` | Passed |
| `pnpm run test:ci` | 62 files, 142 tests passed |
| `pnpm run build:docs` (vite-ssg) | Passed |
| `bash .scripts/docs-ssg-smoke.sh` | `docs-ssg smoke ok` |
| Docs dev server (`localhost:5173`) | HTTP 200, live component pages render + interact |

Docs dev server walkthrough (home page, Button component page with live examples, dark-mode toggle):

[indielayer_ui_docs_dev_server_walkthrough.mp4](https://cursor.com/agents/bc-7a661611-d7e0-45d0-b53b-4d5a9608d22c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Findielayer_ui_docs_dev_server_walkthrough.mp4)

[Docs home page](https://cursor.com/agents/bc-7a661611-d7e0-45d0-b53b-4d5a9608d22c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_home_light.webp)
[Button component docs](https://cursor.com/agents/bc-7a661611-d7e0-45d0-b53b-4d5a9608d22c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_button_light.webp)
[Button docs dark mode](https://cursor.com/agents/bc-7a661611-d7e0-45d0-b53b-4d5a9608d22c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_button_dark.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a661611-d7e0-45d0-b53b-4d5a9608d22c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a661611-d7e0-45d0-b53b-4d5a9608d22c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

