### PR TITLE
fix(popover): flatten nested CSS selectors

### DIFF
--- a/.changeset/chilled-pens-exist.md
+++ b/.changeset/chilled-pens-exist.md
@@ -1,0 +1,7 @@
+---
+"@indielayer/ui": patch
+---
+
+fix(popover): flatten nested CSS selectors
+
+Popover and Scroll SFC styles used nested `&` rules that postcss without tailwindcss/nesting does not compile, which left floating poppers at opacity 0. Flatten selectors so styles work in TW4 apps and the lib build.

--- a/packages/ui/src/components/popover/Popover.vue
+++ b/packages/ui/src/components/popover/Popover.vue
@@ -274,24 +274,24 @@ const { styles, classes, className } = useTheme('Popover', {}, props)
   top: 0;
   left: 0;
   outline: none;
+}
 
-  &.v-popper__popper--hidden {
-    visibility: hidden;
-    opacity: 0;
-    transition: opacity 0.15s, visibility 0.15s;
-    pointer-events: none;
-  }
+.v-popper__popper.v-popper__popper--hidden {
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s, visibility 0.15s;
+  pointer-events: none;
+}
 
-  &.v-popper__popper--shown {
-    visibility: visible;
-    opacity: 1;
-    transition: opacity 0.15s;
-  }
+.v-popper__popper.v-popper__popper--shown {
+  visibility: visible;
+  opacity: 1;
+  transition: opacity 0.15s;
+}
 
-  &.v-popper__popper--skip-transition,
-  &.v-popper__popper.v-popper__popper--skip-transition > .v-popper__wrapper {
-    transition: none !important;
-  }
+.v-popper__popper.v-popper__popper--skip-transition,
+.v-popper__popper.v-popper__popper--skip-transition > .v-popper__wrapper {
+  transition: none !important;
 }
 
 .v-popper__backdrop {

--- a/packages/ui/src/components/scroll/Scroll.vue
+++ b/packages/ui/src/components/scroll/Scroll.vue
@@ -100,69 +100,67 @@ defineExpose({ scrollEl: scrollEl as Ref<HTMLElement | null> })
 </template>
 
 <style module>
-.scrollwrap {
-  &::before,
-  &::after {
-    content: "";
-    pointer-events: none;
-    position: absolute;
-    z-index: 1;
-    transition: box-shadow 0.2s;
-  }
+.scrollwrap::before,
+.scrollwrap::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+  transition: box-shadow 0.2s;
+}
 
-  &.horizontal::before,
-  &.horizontal::after {
-    top: 0;
-    bottom: 0;
-    width: 20px;
-  }
+.scrollwrap.horizontal::before,
+.scrollwrap.horizontal::after {
+  top: 0;
+  bottom: 0;
+  width: 20px;
+}
 
-  &.vertical::before,
-  &.vertical::after {
-    right: 0;
-    left: 0;
-    height: 20px;
-  }
+.scrollwrap.vertical::before,
+.scrollwrap.vertical::after {
+  right: 0;
+  left: 0;
+  height: 20px;
+}
 
-  &.horizontal::before {
-    left: 0;
-  }
+.scrollwrap.horizontal::before {
+  left: 0;
+}
 
-  &.horizontal::after {
-    right: 0;
-  }
+.scrollwrap.horizontal::after {
+  right: 0;
+}
 
-  &.vertical::before {
-    top: 0;
-  }
+.scrollwrap.vertical::before {
+  top: 0;
+}
 
-  &.vertical::after {
-    bottom: 0;
-  }
+.scrollwrap.vertical::after {
+  bottom: 0;
+}
 
-  &.shadow-left::before {
-    box-shadow: inset 12px 0 10px -10px rgb(0 0 0 / 7%);
-  }
+.scrollwrap.shadow-left::before {
+  box-shadow: inset 12px 0 10px -10px rgb(0 0 0 / 7%);
+}
 
-  &.shadow-right::after {
-    box-shadow: inset -12px 0 10px -10px rgb(0 0 0 / 7%);
-  }
+.scrollwrap.shadow-right::after {
+  box-shadow: inset -12px 0 10px -10px rgb(0 0 0 / 7%);
+}
 
-  &.shadow-top::before {
-    box-shadow: inset 0 12px 10px -10px rgb(0 0 0 / 7%);
-  }
+.scrollwrap.shadow-top::before {
+  box-shadow: inset 0 12px 10px -10px rgb(0 0 0 / 7%);
+}
 
-  &.shadow-bottom::after {
-    box-shadow: inset 0 -12px 10px -10px rgb(0 0 0 / 7%);
-  }
+.scrollwrap.shadow-bottom::after {
+  box-shadow: inset 0 -12px 10px -10px rgb(0 0 0 / 7%);
 }
 
 .hidescroll {
   -ms-overflow-style: auto;
   scrollbar-width: none;
+}
 
-  &::-webkit-scrollbar {
-    display: none;
-  }
+.hidescroll::-webkit-scrollbar {
+  display: none;
 }
 </style>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

**Do we need to publish a new version of a package?**
- [x] Add a changeset `pnpm changeset` and select what [semver](https://semver.org/) changes your PR is adding
  - commit and push the generated *changeset* file

### 📝 Checklist
<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

### 📚 Description
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
